### PR TITLE
Adding release notes check into the TAG pipeline process

### DIFF
--- a/.github/templates/release_notes
+++ b/.github/templates/release_notes
@@ -1,0 +1,49 @@
+> Description
+
+### Upgrade Steps
+* [ACTION REQUIRED]
+* 
+
+### Breaking Changes
+* 
+* 
+
+### New Features
+* 
+* 
+
+### Bug Fixes
+* 
+* 
+
+### Performance Improvements
+* 
+* 
+
+### Other Changes
+* 
+* > Description
+
+### Upgrade Steps
+* [ACTION REQUIRED]
+* 
+
+### Breaking Changes
+* 
+* 
+
+### New Features
+* 
+* 
+
+### Bug Fixes
+* 
+* 
+
+### Performance Improvements
+* 
+* 
+
+### Other Changes
+* 
+* 

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -5,8 +5,24 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
+  check-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Verify release notes changes
+        uses: tj-actions/verify-changed-files@v5.5
+        id: changed_files
+        with:
+          files: |
+             .github/workflows/ci-pipeline.yaml
+      - name: Check release notees changes
+        if: steps.changed_files.outputs.files_changed == 'false'
+        run: echo "YOU must add and change the release notes"
+
   build:
     runs-on: ubuntu-latest
+    needs: check-release-notes
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
# Adding release notes check into the TAG pipeline process

## Description

Adding release notes check into the TAG pipeline process


## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## How Has This Been Tested?

Create a tag and push it without changing the release_notes
